### PR TITLE
Bump Zapier version for release

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentql_async",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentql_async",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "agentql-js-common": "^0.0.1",
         "zapier-platform-core": "17.7.2"

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentql_async",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To release the new version of the app, without vulnerabilities (addressed in #16) we need to bump the version beyond 1.0.4.

Given that there should be no breaking changes for this and it was effectively a patch for a vulnerability, I bumped it by only a patch version, from 1.0.4 to 1.05.