### PR TITLE
fix: bump lodash to 4.18.1 (CVE-2026-4800) [ENG-14004]

### DIFF
--- a/zapier/package-lock.json
+++ b/zapier/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.5",
       "dependencies": {
         "agentql-js-common": "^0.0.1",
-        "lodash": ">=4.17.23",
+        "lodash": ">=4.18.0",
         "zapier-platform-core": "^17"
       },
       "devDependencies": {
@@ -3191,9 +3191,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {

--- a/zapier/package.json
+++ b/zapier/package.json
@@ -9,13 +9,13 @@
   "dependencies": {
     "agentql-js-common": "^0.0.1",
     "zapier-platform-core": "^17",
-    "lodash": ">=4.17.23"
+    "lodash": ">=4.18.0"
   },
   "devDependencies": {
     "jest": "^29.6.0"
   },
   "overrides": {
-    "lodash": ">=4.17.23",
+    "lodash": ">=4.18.0",
     "minimatch": "^3.1.3",
     "picomatch": "^2.3.2"
   },


### PR DESCRIPTION
## Summary

Bumps `lodash` from 4.17.23 → **4.18.1** to remediate CVE-2026-4800.

**Vulnerability:** `_.template` does not validate `options.imports` key names, allowing code injection when untrusted input is passed as import keys. Fixed in 4.18.0 (validates keys via `reForbiddenIdentifierChars` + uses `assignWith` instead of `assignInWith`).

**Severity:** HIGH | **SLA:** 2026-05-03 | **Linear:** ENG-14004

Updated both `dependencies` and `overrides` in `zapier/package.json` to `>=4.18.0`.

## Test plan
- [ ] CI passes
- [ ] Verify `lodash@4.18.1` in `zapier/package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)