### PR TITLE
fix(security): bump python-dotenv 1.2.1->1.2.2, suppress langchain-text-splitters SSRF (ENG-14769/14677)

### DIFF
--- a/langchain/poetry.lock
+++ b/langchain/poetry.lock
@@ -2486,14 +2486,14 @@ watchdog = ">=2.0.0"
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
-    {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -3857,4 +3857,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "ddb627334210a7ed2409ba7e51258b52cf0af9c2a11c76bf9f241392d5bd258d"
+content-hash = "b757a3a394205656ba4b6e7193fd30c49fbb04ee1e91f997d4989af3982a5616"

--- a/langchain/pyproject.toml
+++ b/langchain/pyproject.toml
@@ -33,6 +33,7 @@ orjson = ">=3.11.6"
 requests = ">=2.33.0"
 pygments = ">=2.20.0"
 aiohttp = ">=3.13.5"
+python-dotenv = ">=1.2.2"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,4 +1,9 @@
 [[IgnoredVulns]]
+id = "GHSA-fv5p-p927-qmxr"
+ignoreUntil = "2026-07-24T00:00:00Z"
+reason = "langchain-text-splitters SSRF redirect bypass in HTMLHeaderTextSplitter.split_text_from_url (MEDIUM). Fix requires langchain-text-splitters>=1.1.2 which requires langchain-core>=1.2.31 — a breaking major change. langchain-community 0.3.x hard-constrains langchain-core<1.0.0, making a semver-compatible upgrade impossible. HTMLHeaderTextSplitter is not used by langchain-agentql. Related: ENG-14677."
+
+[[IgnoredVulns]]
 id = "GHSA-2g6r-c272-w58r"
 ignoreUntil = "2026-06-15T00:00:00Z"
 reason = "langchain-core SSRF via image_url token counting (LOW). Fix requires upgrading langchain-core 0.3.x -> 1.2.11, a breaking major version change incompatible with our ^0.3.15 constraint. No semver-compatible fix available."


### PR DESCRIPTION
## Vulnerability Fix

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| python-dotenv | 1.2.1 | 1.2.2 | CVE-2026-28684 | Medium | ✅ Fixed |
| langchain-text-splitters | 0.3.11 | — | GHSA-fv5p-p927-qmxr | Medium | ⚠️ Risk accepted — fix requires >=1.1.2 which needs langchain-core>=1.2.31 (breaking; langchain-community 0.3.x pins langchain-core<1.0.0) |

**Linear:** https://linear.app/tinyfish/issue/ENG-14769 | https://linear.app/tinyfish/issue/ENG-14677

## Summary

- Adds explicit `python-dotenv = ">=1.2.2"` floor pin to `langchain/pyproject.toml` — fixes CVE-2026-28684 (symlink-following file overwrite in `set_key()`/`unset_key()`).
- Suppresses GHSA-fv5p-p927-qmxr (langchain-text-splitters SSRF redirect bypass): fix requires `langchain-text-splitters>=1.1.2` which requires `langchain-core>=1.2.31` — breaking major change incompatible with `langchain-community 0.3.x`. `HTMLHeaderTextSplitter.split_text_from_url()` is not called by this integration package.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| python-dotenv | 1.2.1 | 1.2.2 | Patch/security | CVE-2026-28684 fix (symlink follow); no API changes |

</details>

All changes are limited to manifest/lock file version bumps and osv-scanner.toml suppression entries — no functional source code changes.