### PR TITLE
fix(security): fix osv-scanner.toml format + suppress langchain vulns (ENG-14837)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,19 +1,24 @@
 [[IgnoredVulns]]
 id = "GHSA-fv5p-p927-qmxr"
-ignoreUntil = "2026-07-24T00:00:00Z"
+ignoreUntil = 2026-07-24
 reason = "langchain-text-splitters SSRF redirect bypass in HTMLHeaderTextSplitter.split_text_from_url (MEDIUM). Fix requires langchain-text-splitters>=1.1.2 which requires langchain-core>=1.2.31 — a breaking major change. langchain-community 0.3.x hard-constrains langchain-core<1.0.0, making a semver-compatible upgrade impossible. HTMLHeaderTextSplitter is not used by langchain-agentql. Related: ENG-14677."
 
 [[IgnoredVulns]]
 id = "GHSA-2g6r-c272-w58r"
-ignoreUntil = "2026-06-15T00:00:00Z"
+ignoreUntil = 2026-06-15
 reason = "langchain-core SSRF via image_url token counting (LOW). Fix requires upgrading langchain-core 0.3.x -> 1.2.11, a breaking major version change incompatible with our ^0.3.15 constraint. No semver-compatible fix available."
 
 [[IgnoredVulns]]
 id = "GHSA-qh6h-p6c9-ff54"
-ignoreUntil = "2026-07-16T00:00:00Z"
+ignoreUntil = 2026-07-16
 reason = "langchain-core path traversal in load_prompt/load_prompt_from_config (HIGH, CVE-2026-34070). Fix requires upgrading langchain-core 0.3.x -> 1.2.22, a breaking major version change. langchain-community 0.3.x hard-constrains langchain-core<1.0.0, making a semver-compatible upgrade impossible without also migrating langchain-community to a stable 1.x release (currently only alpha). No fix available in the 0.3.x line."
 
 [[IgnoredVulns]]
 id = "GHSA-6w46-j5rx-g56g"
-ignoreUntil = "2026-07-16T00:00:00Z"
+ignoreUntil = 2026-07-16
 reason = "pytest tmpdir privilege escalation (CVE-2025-71176, MEDIUM). Fix requires pytest>=9.0.3, but langchain-tests<=0.3.x pins pytest<9. Upgrading langchain-tests to 1.x would require a full langchain ecosystem migration (langchain-core 0.3->1.x, langchain-community 0.3->1.x). Affects test execution only — no production exposure. ENG-14433."
+
+[[IgnoredVulns]]
+id = "GHSA-r7w7-9xr2-qq2r"
+ignoreUntil = 2026-07-27
+reason = "langchain-openai prompt injection via tool result injection (LOW). Fix requires langchain-openai>=0.4.4 which requires langchain-core>=1.3.1 — a breaking major change. langchain-community 0.3.x hard-constrains langchain-core<1.0.0, making a semver-compatible upgrade impossible. ENG-14837."


### PR DESCRIPTION
## Vulnerabilities

| Package | Old | New | Advisory | CVSS | Status |
|---------|-----|-----|----------|------|--------|
| langchain-core | 0.3.x | — | GHSA-qh6h-p6c9-ff54 | HIGH | ⚠️ Risk accepted — fix requires langchain 0.3→1.x migration (see osv-scanner.toml) |
| langchain-text-splitters | 0.3.x | — | GHSA-fv5p-p927-qmxr | MEDIUM | ⚠️ Risk accepted — same blocker |
| langchain-core | 0.3.x | — | GHSA-2g6r-c272-w58r | LOW | ⚠️ Risk accepted — same blocker |
| pytest | 8.x | — | GHSA-6w46-j5rx-g56g | MEDIUM | ⚠️ Risk accepted — langchain-tests 0.3.x pins pytest<9 |
| langchain-openai | 0.3.x | — | GHSA-r7w7-9xr2-qq2r | LOW | ⚠️ Risk accepted — fix requires langchain-core>=1.3.1 (breaking) |

All changes are limited to osv-scanner.toml — no functional source code changes.

## Changes

- **Fixed `ignoreUntil` format**: Corrected 4 existing suppressions from quoted RFC3339 strings (`"2026-07-16T00:00:00Z"`) to unquoted TOML local dates (`2026-07-16`). The quoted form passes TOML parsing silently but is invalid per osv-scanner spec.
- **Added GHSA-r7w7-9xr2-qq2r suppression**: langchain-openai prompt injection (LOW) — fix requires langchain-openai>=0.4.4 which requires langchain-core>=1.3.1, blocked by langchain-community 0.3.x's hard `langchain-core<1.0.0` constraint.

## Root Cause of All Suppressions

All 5 langchain vulnerabilities are blocked by the same fundamental constraint: `langchain-community 0.3.x` hard-pins `langchain-core<1.0.0`. All security fixes require `langchain-core>=1.x`. This is a breaking ecosystem migration with no 0.3.x-compatible fix available. Tracked in ENG-14677 for future migration planning.

<details>
<summary>Changelog impact summary</summary>

| Package | Old | New | Classification | Key changes |
|---------|-----|-----|----------------|-------------|
| osv-scanner.toml | — | — | Config fix only | Format correction + 1 new suppression entry |

</details>