### PR TITLE
fix(security): extend langchain-core SSRF suppress to 2026-07-30 (ENG-12311)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -5,8 +5,8 @@ reason = "langchain-text-splitters SSRF redirect bypass in HTMLHeaderTextSplitte
 
 [[IgnoredVulns]]
 id = "GHSA-2g6r-c272-w58r"
-ignoreUntil = 2026-06-15
-reason = "langchain-core SSRF via image_url token counting (LOW). Fix requires upgrading langchain-core 0.3.x -> 1.2.11, a breaking major version change incompatible with our ^0.3.15 constraint. No semver-compatible fix available."
+ignoreUntil = 2026-07-30
+reason = "langchain-core SSRF via image_url token counting (LOW, CVE-2026-26013). Fix requires upgrading langchain-core 0.3.x -> 1.2.11, a breaking major version change incompatible with our ^0.3.15 constraint. No semver-compatible fix available. ENG-12311."
 
 [[IgnoredVulns]]
 id = "GHSA-qh6h-p6c9-ff54"


### PR DESCRIPTION
## Vulnerability

| Package | Advisory | CVSS | Status |
|---------|----------|------|--------|
| langchain-core | [GHSA-2g6r-c272-w58r](https://github.com/advisories/GHSA-2g6r-c272-w58r) (CVE-2026-26013) | LOW | ⚠️ Risk accepted — suppress extended to 2026-07-30 |

**Ticket:** ENG-12311

**Blocker:** Fix requires `langchain-core 0.3.x → 1.2.11` (major breaking change). `langchain-community 0.3.x` hard-constrains `langchain-core<1.0.0`, making a semver-compatible upgrade impossible. Existing suppress was expiring 2026-06-15; extended to 2026-07-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)